### PR TITLE
在 `stderr` 里输出“服务启动成功”消息

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ async function startMcpServer() {
     description: "Provides documentation and example for Taroify components",
   });
 
-  console.log("服务启动成功");
+  console.error("服务启动成功");
 
   registerTaroifyTools(server);
 


### PR DESCRIPTION
“服务启动成功”的消息当前是在 `stdout`里输出，在 codex 里使用时报错:
```
⚠ MCP client for `taroify` failed to start: MCP startup failed: handshaking with MCP server failed: connection closed: initialize response

⚠ MCP startup incomplete (failed: taroify)
```